### PR TITLE
createCert - Added status code 502 to createCert

### DIFF
--- a/src/openapi/AccountManager.yaml
+++ b/src/openapi/AccountManager.yaml
@@ -530,6 +530,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        502:
+          description: CMP-Service nicht erreichbar bzw. liefert Fehler          
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 ##--
 ##------
   /account/{username}/outofoffice:


### PR DESCRIPTION
Added status code 502 to createCert, as this functionality depends on a external service (CMP service) which might also cause errors.

This is also consistent to the handling for VZD related errors, as the VZD is also an external service.

See ticket: ANFKIM-262