### PR TITLE
Adjustment AccountManager.revokeDeregistration - HTTP response codes 400 & 403

### DIFF
--- a/src/openapi/AccountManager.yaml
+++ b/src/openapi/AccountManager.yaml
@@ -394,8 +394,20 @@ paths:
       responses:
         204:
           description: Deregistrierung erolgreich zurückgenommen
+        400:
+          description: Fehler in den Eingangsdaten, Beschreibung des Fehlers erfolgt in dem Fehlertext
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         401:
           description: Authentifizierung fehlgeschlagen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: Email Account wurde bisher nicht deregistriert
           content:
             application/json:
               schema:


### PR DESCRIPTION
- Added error code 400 for consistency sake
- Added error code 403 to imply the forbidden operation in case the e-mail account wasn´t deregistered or isn´t in deregistered state