### PR TITLE
Feature request: KAS processing threshold provided by AccountLimit

### DIFF
--- a/src/openapi/AccountLimit.yaml
+++ b/src/openapi/AccountLimit.yaml
@@ -2,7 +2,9 @@ openapi: 3.0.3
 info:
   title: I_AccountLimit_Service
   description:  Über diese Schnittstelle werden die Limits eines Nutzer-Accounts abgefragt
-  version: 1.1.1
+  version: 1.1.2
+  ### 1.1.2
+  # - added object property AccountLimit.kasMailSizeThreshold
   ### 1.1.1
   # - changed minimum value for maxMailSize
   # - changed descriptions
@@ -84,6 +86,14 @@ components:
           minimum: 734003200
           example: 734003200
           description: Setzt die maximale Größe einer KIM-Mail in Bytes
+        kasMailSizeThreshold:
+          type: integer
+          format: int64
+          readOnly: true
+          minimum: 1048576
+          maximum: 15728640
+          default: 15728640
+          description: Schwellwert der im KIM-Clientmodul empfangenen Datenmenge, ab dem die Daten über den definierten KAS-Prozess verarbeitet werden.
         quota:
           type: integer
           format: int64


### PR DESCRIPTION
Starting with KIM 1.5 specification, the current threshold from which a KIM-Clientmodul processes received/large mail data by the defined 'KAS process' is fixed to 15 MiB. Any KIM mail smaller than 15 MiB must be processed 'normally'/fully by TI-Konnektor.

To mitigate the known performance & memory issues of the TI-Konnektor, it might be benefitial to allow a smaller, by all means, variable threshold from which the KIM-Clientmodul uses the 'KAS process' instead of processing large amounts of data by a TI-Konnektor.

Solution:
Extend AccountLimit by a property 'kasMailSizeThreshold', which allows a threshold between 1 MiB and 15 MiB (default). Currently any KIM-Clientmodul implementing KIM 1.5 specification must request the AccountLimit before sending a message.

Advantage:
- This might increase the overall performance, e.g. by reducing the time required to send or receive KIM messages.
- As the AccountLimit already implies account-wise information, a KIM provider is enabled to set a threshold account-wise or globally for any account.

Disadvantage:
- A low threshold might result in more data stored on the KAS. This data isn´t explicitly managed by client´s or client software. Thus the on the KAS stored data is primarly managed through deletion by expiration (dataTimeToLive).

The KIM/KAS provider must decide/manage the threshold value, as the overall KAS performance and related storage management might be individual to each provider.