### PR TITLE
Feature request: Extend the Error object with an id for tracing errors

### DIFF
--- a/src/openapi/AccountLimit.yaml
+++ b/src/openapi/AccountLimit.yaml
@@ -99,13 +99,13 @@ components:
     Error:
       type: object
       properties:
+        message:
+          type: string
         traceId:
           type: string
           maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
-        message:
-          type: string
 
   securitySchemes:
     basicAuth:

--- a/src/openapi/AccountLimit.yaml
+++ b/src/openapi/AccountLimit.yaml
@@ -6,6 +6,7 @@ info:
   ### 1.1.1
   # - changed minimum value for maxMailSize
   # - changed descriptions
+  # - added traceId to Error object
   ### 1.1
   # - changed version number in server url
   # - removed quotation marks and added minimum value for maxMailSize
@@ -98,6 +99,10 @@ components:
     Error:
       type: object
       properties:
+        traceId:
+          type: string
+          example: 19aaf69260f63694
+          description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:
           type: string
 

--- a/src/openapi/AccountLimit.yaml
+++ b/src/openapi/AccountLimit.yaml
@@ -101,6 +101,7 @@ components:
       properties:
         traceId:
           type: string
+          maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:

--- a/src/openapi/AccountManager.yaml
+++ b/src/openapi/AccountManager.yaml
@@ -811,6 +811,7 @@ components:
       properties:
         traceId:
           type: string
+          maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:

--- a/src/openapi/AccountManager.yaml
+++ b/src/openapi/AccountManager.yaml
@@ -809,13 +809,13 @@ components:
     Error:
       type: object
       properties:
+        message:
+          type: string
         traceId:
           type: string
           maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
-        message:
-          type: string
 
     Account:
       type: object

--- a/src/openapi/AccountManager.yaml
+++ b/src/openapi/AccountManager.yaml
@@ -11,6 +11,7 @@ info:
   # - descriptions changed
   # - read only parameter in setAccount removed
   # - new parameter appTags in registerAccount and setAccount
+  # - added traceId to Error object
   ### 2.3.0
   # - change server url to new api version
   # - added /account/{username}/revokeDeregistration
@@ -808,6 +809,10 @@ components:
     Error:
       type: object
       properties:
+        traceId:
+          type: string
+          example: 19aaf69260f63694
+          description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:
           type: string
 

--- a/src/openapi/AttachmentService.yaml
+++ b/src/openapi/AttachmentService.yaml
@@ -286,6 +286,7 @@ components:
       properties:
         traceId:
           type: string
+          maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:

--- a/src/openapi/AttachmentService.yaml
+++ b/src/openapi/AttachmentService.yaml
@@ -8,6 +8,7 @@ info:
   # - added distinct definition for header element Content-Length in add_Attachment:
   #   - Content-Length full request body
   #   - Conent-Length of the actual mail data of the "attachment" form-data in body, which is required in order to check against maxMailSize + performant storage streaming
+  # - added traceId to Error object
   ### 2.3.1
   # - added delete_Maildata feature
   ### 2.3.0
@@ -283,6 +284,10 @@ components:
     Error:
       type: object
       properties:
+        traceId:
+          type: string
+          example: 19aaf69260f63694
+          description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:
           type: string
 

--- a/src/openapi/AttachmentService.yaml
+++ b/src/openapi/AttachmentService.yaml
@@ -284,13 +284,13 @@ components:
     Error:
       type: object
       properties:
+        message:
+          type: string
         traceId:
           type: string
           maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
-        message:
-          type: string
 
   securitySchemes:
     basicAuth:

--- a/src/openapi/ServiceInformation.yaml
+++ b/src/openapi/ServiceInformation.yaml
@@ -74,6 +74,7 @@ components:
       properties:
         traceId:
           type: string
+          maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:

--- a/src/openapi/ServiceInformation.yaml
+++ b/src/openapi/ServiceInformation.yaml
@@ -5,6 +5,7 @@ info:
   version: 1.0.0
   ### 1.0.0
   # - initial Version of I_ServiceInformation
+  # - added traceId to Error object
 
 externalDocs:
   description: GitHub - Dokumentation
@@ -71,5 +72,9 @@ components:
     Error:
       type: object
       properties:
+        traceId:
+          type: string
+          example: 19aaf69260f63694
+          description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
         message:
           type: string

--- a/src/openapi/ServiceInformation.yaml
+++ b/src/openapi/ServiceInformation.yaml
@@ -72,10 +72,10 @@ components:
     Error:
       type: object
       properties:
+        message:
+          type: string
         traceId:
           type: string
           maxLength: 255
           example: 19aaf69260f63694
           description: Eindeutige Zeichenkette zur Rückverfolgung des Fehlers im Fachdienst
-        message:
-          type: string


### PR DESCRIPTION
# Context

In the course of troubleshooting, it may be necessary to check the log entries or protocol entries of the Fachdienst to determine the cause of the error. In practice, backend services often generate unique IDs (tracing IDs) to identify client calls or conversations (e.g. B3). These IDs are printed in log entries to improve traceability. 

# Improvement

The API definitions for I_AccountLimit_Service, I_AccountManager_Service, I_Attachment_Service and I_ServiceInformation define an Error object (components.schemas.Error) to return an error message if an error occurs when calling one of the endpoints. It would be very helpful to extend the error object with a trace id, so that in case of an error the log entries belonging to the call can be found quickly.

