### PR TITLE
Specify DateTime type in out of office

### DIFF
--- a/docs/KIM_API.adoc
+++ b/docs/KIM_API.adoc
@@ -771,6 +771,20 @@ Die Operation `getOutOfOffice()` liefert Informationen zu eingestellten Abwesenh
 ----
 |Body    |
 keine Parameter
+|Antwort    |
+[source, json]
+----
+{
+  "startDate": "2021-07-28T00:00:00.000Z",
+  "endDate": "2021-08-01T00:00:00Z",
+  "message": "Sehr geehrte Damen und Herren...",
+  "active": "true"
+}
+----
+[normal]#`startDate` - Ab diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet (https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339 Section 5.6])# +
+[normal]#`endDate` - Bis zu diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet (https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339 Section 5.6])# +
+[normal]#`message` - Inhalt der Abwesenheitsnotiz# +
+[normal]#`active` - Aktivieren bzw. deaktiviert der Abwesenheitsnotiz#
 |===
 
 *Beispielabfrage:*
@@ -788,8 +802,8 @@ curl -X 'GET' \
 Code: 200
 Body:
 {
-  "startDate": {2021-07-28T00:00:00Z},
-  "endDate": {2021-08-01T00:00:00Z},
+  "startDate": "2021-07-28T00:00:00.000Z",
+  "endDate": "2021-08-01T00:00:00Z",
   "message": "Sehr geehrte Damen und Herren...",
   "active": true
 }
@@ -834,14 +848,14 @@ Die Operation `UpdateOutOfOffice()` ermöglicht das Einstellen einer Abwesenheit
 [source, json]
 ----
 {
-  "startDate": "{2021-07-28T00:00:00Z}",
-  "endDate": "{2021-08-01T00:00:00Z}",
+  "startDate": "2021-07-28T00:00:00.000Z",
+  "endDate": "2021-08-01T00:00:00Z",
   "message": "Sehr geehrte Damen und Herren...",
   "active": "true"
 }
 ----
-[normal]#`startDate` - Ab diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet# +
-[normal]#`endDate` - Bis zu diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet# +
+[normal]#`startDate` - Ab diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet (https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339 Section 5.6])# +
+[normal]#`endDate` - Bis zu diesem Zeitpunkt wird die Abwesenheitsnotiz gesendet (https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339 Section 5.6])# +
 [normal]#`message` - Inhalt der Abwesenheitsnotiz# +
 [normal]#`active` - Aktivieren bzw. deaktiviert der Abwesenheitsnotiz#
 |===
@@ -856,8 +870,8 @@ curl -X 'PUT' \
   -H 'password: password' \
   -H 'Content-Type: application/json' \
   -d '{
-  "startDate": {2021-07-28T00:00:00Z},
-  "endDate": {2021-08-01T00:00:00Z},
+  "startDate": "2021-07-28T00:00:00Z",
+  "endDate": "2021-08-01T00:00:00.000Z",
   "message": "Sehr geehrte Damen und Herren...",
   "active": true
 }'


### PR DESCRIPTION
Bei der get und update OutOfOffice fehlt die Referenz zum DateTime Format (https://datatracker.ietf.org/doc/html/rfc3339#section-5.6). Diese ist nur implizit durch die OpenAPI Definition string($DateTime) ersichtlich, aber nicht in den Beispiele, welche zusätzlich noch ein falsches Format mit geschweiften Klammern aufweisen.

Es wurden die Beispiele angepasst und ein Verweist auf das RFC hinzugefügt.