### PR TITLE
Integration der 'X-KIM-Encounter-Id' in KIM-Spezifikation

### DIFF
--- a/docs/Primaersystem.adoc
+++ b/docs/Primaersystem.adoc
@@ -154,6 +154,8 @@ Die autorisierten Personen werden mit dem KIM-Antrag festgelegt.
 Bei Anwendung der SASL-Mechanismen `PLAIN` und `LOGIN` für die SMTP-Authentifizierung ist es erforderlich, dass das Primärsystem einen persistent gespeicherten SMTP-Benutzernamen gemäß der Tabelle: _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ verwendet. Das Passwort, das zur Authentifizierung gegenüber dem KIM-Dienst (MTA) verwendet wird, wird ebenfalls dem persistenten Datensatz entnommen. Die Attribute der Tabelle
 _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ werden durch das „#“ – Zeichen getrennt.
 
+* *Verwendung der 'X-KIM-Encounter-Id'* +
+Für die Nachverfolgbarkeit von Nachrichten im Kontext eines bestimmten Behandlungsfalls (Encounter) ist es erforderlich, dass das Primärsystem das Header-Element `X-KIM-Encounter-Id` in jeder KIM-Nachricht befüllt. Dieses Header-Element muss eine eindeutige Identifikationsnummer (z.B. eine UUID) enthalten, die für den gesamten Nachrichtenverlauf eines spezifischen Behandlungsfalls konstant bleibt. Bei der Erstellung einer Antwort auf eine Nachricht muss das Empfängersystem die `X-KIM-Encounter-Id` der ursprünglichen Nachricht übernehmen, um die Nachrichten einem gemeinsamen Behandlungsfall zuzuordnen. Wenn eine Encounter-FHIR-Ressource im Body der Nachricht enthalten ist, muss der `Encounter.identifier` mit dem Wert in der `X-KIM-Encounter-Id` übereinstimmen.
 
 [cols="1,2",options="header",autowidth]
 .Tab_ILF_PS_Bildungsregel_SMTP_Benutzername

--- a/docs/Primaersystem.adoc
+++ b/docs/Primaersystem.adoc
@@ -157,6 +157,7 @@ Die autorisierten Personen werden mit dem KIM-Antrag festgelegt.
 Bei Anwendung der SASL-Mechanismen `PLAIN` und `LOGIN` für die SMTP-Authentifizierung ist es erforderlich, dass das Primärsystem einen persistent gespeicherten SMTP-Benutzernamen gemäß der Tabelle: _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ verwendet. Das Passwort, das zur Authentifizierung gegenüber dem KIM-Dienst (MTA) verwendet wird, wird ebenfalls dem persistenten Datensatz entnommen. Die Attribute der Tabelle
 _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ werden durch das „#“ – Zeichen getrennt.
 
+
 [cols="1,2",options="header",autowidth]
 .Tab_ILF_PS_Bildungsregel_SMTP_Benutzername
 |===

--- a/docs/Primaersystem.adoc
+++ b/docs/Primaersystem.adoc
@@ -142,6 +142,9 @@ Es ist erforderlich, dass das Primärsystem ausschließlich mit dem Clientmodul 
 * *SMTP-Authentifizierung über KIM–Clientmodul* +
 Für die SMTP-Authentifizierung über das Clientmodul ist es erforderlich, dass das Primärsystem die SASL-Mechanismen `PLAIN` und `LOGIN` verwendet.
 
+* *Verwendung der 'X-KIM-Encounter-Id'* +
+Für die Nachverfolgbarkeit von Nachrichten im Kontext eines bestimmten Behandlungsfalls (Encounter) ist es erforderlich, dass das Primärsystem das Header-Element `X-KIM-Encounter-Id` in jeder KIM-Nachricht befüllt. Dieses Header-Element muss eine eindeutige Identifikationsnummer (z.B. eine UUID) enthalten, die für den gesamten Nachrichtenverlauf eines spezifischen Behandlungsfalls konstant bleibt. Bei der Erstellung einer Antwort auf eine Nachricht muss das Empfängersystem die `X-KIM-Encounter-Id` der ursprünglichen Nachricht übernehmen, um die Nachrichten einem gemeinsamen Behandlungsfall zuzuordnen. Wenn eine Encounter-FHIR-Ressource im Body der Nachricht enthalten ist, muss der `Encounter.identifier` mit dem Wert in der `X-KIM-Encounter-Id` übereinstimmen.
+
 Beim Aufbau der SMTP-Verbindung ist es erforderlich, Kartenverwaltungsinformationen zur SM-B mitzuliefern, die zum Integritätsschutz der
 Nachricht verwendet werden sollen. Dazu müssen `MandantId`, `ClientsystemId` und `WorkplaceId`, der Kartensitzung der erforderlichen SM-B,
 über den SMTP-Benutzernamen dem Clientmodul mitgeteilt werden.
@@ -153,9 +156,6 @@ Die autorisierten Personen werden mit dem KIM-Antrag festgelegt.
 * *Angaben zum Aufbau der SMTP-Verbindung zum KIM-Clientmodul* +
 Bei Anwendung der SASL-Mechanismen `PLAIN` und `LOGIN` für die SMTP-Authentifizierung ist es erforderlich, dass das Primärsystem einen persistent gespeicherten SMTP-Benutzernamen gemäß der Tabelle: _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ verwendet. Das Passwort, das zur Authentifizierung gegenüber dem KIM-Dienst (MTA) verwendet wird, wird ebenfalls dem persistenten Datensatz entnommen. Die Attribute der Tabelle
 _Tab_ILF_PS_Bildungsregel_SMTP_Benutzername_ werden durch das „#“ – Zeichen getrennt.
-
-* *Verwendung der 'X-KIM-Encounter-Id'* +
-Für die Nachverfolgbarkeit von Nachrichten im Kontext eines bestimmten Behandlungsfalls (Encounter) ist es erforderlich, dass das Primärsystem das Header-Element `X-KIM-Encounter-Id` in jeder KIM-Nachricht befüllt. Dieses Header-Element muss eine eindeutige Identifikationsnummer (z.B. eine UUID) enthalten, die für den gesamten Nachrichtenverlauf eines spezifischen Behandlungsfalls konstant bleibt. Bei der Erstellung einer Antwort auf eine Nachricht muss das Empfängersystem die `X-KIM-Encounter-Id` der ursprünglichen Nachricht übernehmen, um die Nachrichten einem gemeinsamen Behandlungsfall zuzuordnen. Wenn eine Encounter-FHIR-Ressource im Body der Nachricht enthalten ist, muss der `Encounter.identifier` mit dem Wert in der `X-KIM-Encounter-Id` übereinstimmen.
 
 [cols="1,2",options="header",autowidth]
 .Tab_ILF_PS_Bildungsregel_SMTP_Benutzername


### PR DESCRIPTION
# Änderungsdetails:

* Einführung eines neuen Header-Elements: 'X-KIM-Encounter-Id'.
* Zweck: Eindeutige Identifikation und Nachverfolgung von Nachrichten innerhalb eines Behandlungsfalls (Encounter).
* Spezifikation: Die 'X-KIM-Encounter-Id' soll eine UUID enthalten, die über den gesamten Nachrichtenverlauf eines Behandlungsfalls konstant bleibt.
* Implementierung: Bei Antworten muss das Empfängersystem die 'X-KIM-Encounter-Id' der ursprünglichen Nachricht übernehmen.
* FHIR-Kompatibilität: Bei Vorhandensein einer Encounter-FHIR-Ressource im Nachrichten-Body muss der Encounter.identifier mit der 'X-KIM-Encounter-Id' übereinstimmen.


# Ziel der Änderung:
Verbesserung der Nachverfolgbarkeit und konsistenten Zuordnung von Nachrichten zu spezifischen Behandlungsfällen.